### PR TITLE
Bumps console-link-cronjob version to v0.1.1

### DIFF
--- a/chart/console-link-job/Chart.yaml
+++ b/chart/console-link-job/Chart.yaml
@@ -24,5 +24,5 @@ appVersion: 1.16.0
 
 dependencies:
   - name: console-link-cronjob
-    version: v0.1.0
+    version: v0.1.2
     repository: https://charts.cloudnativetoolkit.dev/


### PR DESCRIPTION
Signed-off-by: Sean Sundberg <seansund@us.ibm.com>