### PR TITLE
Bumps console-link-cronjob chart to v0.2.0

### DIFF
--- a/chart/console-link-job/Chart.yaml
+++ b/chart/console-link-job/Chart.yaml
@@ -24,5 +24,5 @@ appVersion: 1.16.0
 
 dependencies:
   - name: console-link-cronjob
-    version: v0.1.2
+    version: v0.2.0
     repository: https://charts.cloudnativetoolkit.dev/


### PR DESCRIPTION
- Adds generation of config map from console link annotations

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>